### PR TITLE
Remove .pullapprove.yml

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,1 +1,0 @@
-extends: ui


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #9

# CHANGELOG

* **Removed** `.pullapprove.yml` since PullApprove is not used on this repo.
