### PR TITLE
Make npm package slightly smaller

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,9 +7,14 @@
 .bowerrc
 .editorconfig
 .ember-cli
+.eslintignore
+.eslintrc
+.github
 .gitignore
 .jshintrc
+.remarkrc
 .watchmanconfig
+.travis
 .travis.yml
 bower.json
 dependency-snapshot.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 /bower_components
-/config/ember-try.js
+/config
 /dist
 /tests
 /tmp
@@ -12,5 +12,6 @@
 .watchmanconfig
 .travis.yml
 bower.json
+dependency-snapshot.json
 ember-cli-build.js
 testem.js


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG

* **Removed** unnecessary files from npm package so the package is slightly smaller to pull down. The package from npm will now contain the following:

  *  `blueprints/`
     * `ember-redux-thunk-shim/`
       * `index.js`
  * `CHANGELOG.md`
  * `index.js`
  * `LICENSE.md`
  * `packag.json`
  * `README.md`