### PR TITLE
Upgrade to Ember 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-2-7
   - EMBER_TRY_SCENARIO=ember-2-8
   - EMBER_TRY_SCENARIO=ember-2-9
+  - EMBER_TRY_SCENARIO=ember-2-10
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-redux-thunk-shim",
   "dependencies": {
-    "ember": "^2.10.2",
+    "ember": "^2.11.0",
     "ember-cli-shims": "0.1.1",
     "ember-mocha-adapter": "^0.3.1"
   }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -139,6 +139,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-2-10',
+      bower: {
+        dependencies: {
+          'ember': '~2.10.0'
+        },
+        resolutions: {
+          'ember': '~2.10.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "^2.10.1",
+    "ember-cli": "^2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "0.3.2",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** to test against Ember 2.11.
